### PR TITLE
Adds support for ClojureScript

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject tween-clj "0.5.0"
-  :description "Tweening library for clojure"
+(defproject tween-clj "0.6.0-SNAPSHOT"
+  :description "Tweening library for Clojure(Script)"
   :url "https://github.com/gstamp/tween-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "1.7.28"]]
   :profiles {:dev {:plugins [[cider/cider-nrepl "0.8.0-SNAPSHOT"]
                              [org.clojure/tools.trace "0.7.8"]]}}
   :global-vars {*warn-on-reflection* true
-                *assert* true}
-  )
+                *assert* true})

--- a/src/tween_clj/core.cljc
+++ b/src/tween_clj/core.cljc
@@ -1,4 +1,5 @@
-(ns tween-clj.core)
+(ns tween-clj.core
+  #?(:cljs (:require [tween-clj.math-interop :as Math])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Transition types

--- a/src/tween_clj/math_interop.cljs
+++ b/src/tween_clj/math_interop.cljs
@@ -1,0 +1,7 @@
+(ns tween-clj.math-interop)
+
+(def PI js/Math.PI)
+(def pow js/Math.pow)
+(def sin js/Math.sin)
+(def cos js/Math.cos)
+(def acos js/Math.acos)


### PR DESCRIPTION
Thanks for your library, @gstamp! I successfully ported ClojureScript support into my fork, and I wanted to offer those (relatively minor) changes upstream:

* `src/`: The `tween-clj.math-interop` namespace defines JavaScript analogues for the `java.lang.Math` methods used in `tween-clj.core`.
* `project.clj`: Dependencies updated to support reader conditionals
* `project.clj`: Version and description tweaks (please feel free to alter these to your preferences)